### PR TITLE
Output exact target position

### DIFF
--- a/data/iris/functions/get_target.mcfunction
+++ b/data/iris/functions/get_target.mcfunction
@@ -30,22 +30,28 @@
 #       TargetedBlock: int[]
 #           The integer coordinates of the block that is hit
 #           Corresponds to the "Targeted Block" field in the debug screen
-#           Unset if the ray hits an entity or if no block is found
+#           Unset if TargetType is not BLOCK
 #       TargetedEntity: int
 #           The ID of the targeted entity on objective iris.entity_id
 #           The entity executing this function cannot be targeted
-#           Unset if the ray first hits a block or if no entity is found
+#           Unset if TargetType is not ENTITY
+#       TargetPosition
+#           Unset if TargetType is NONE
+#           tile: int[]
+#               The integer coordinates of the last traversed tile
+#           point: double[]
+#               Where exactly the ray hits an obstacle within the last traversed tile, as three coordinates between 0 and 1
 #       Distance: double
 #           How long the ray travels before hitting an obstacle
-#           Unset if no block or entity is found
+#           Unset if TargetType is NONE
 #       TargetedBox: compound
-#           The axis-aligned bounding box that was hit within the targeted block, as six coordinates between 0 and 1
-#           Unset if the ray first hits an entity or if no block is found
+#           The axis-aligned bounding box that was hit within the last traversed tile, as six coordinates between 0 and 1
+#           Unset if TargetType is NONE
 #           min: double[]
 #           max: double[]
 #       TargetedFace: compound
-#           The face ŧhat was hit within the targeted block, as six coordinates between 0 and 1
-#           Unset if the ray first hits an entity or if no block is found
+#           The face ŧhat was hit within the last traversed tile, as six coordinates between 0 and 1
+#           Unset if TargetType is NONE
 #           min: double[]
 #           max: double[]
 #           Direction: string
@@ -67,6 +73,7 @@ scoreboard players reset * iris.id
 data modify storage iris:output TargetType set value "NONE"
 data remove storage iris:output TargetedBlock
 data remove storage iris:output TargetedEntity
+data remove storage iris:output TargetPosition
 data remove storage iris:output Distance
 data remove storage iris:output TargetedBox
 data remove storage iris:output TargetedFace

--- a/data/iris/functions/raycast/check_intersection/ray_box.mcfunction
+++ b/data/iris/functions/raycast/check_intersection/ray_box.mcfunction
@@ -29,16 +29,21 @@ execute if score $dz iris matches ..-1 run data modify storage iris:data Faces[2
 # Check for ray-plane intersections
 data modify storage iris:data Face set from storage iris:data Faces[0]
 execute store success score $hits_x_face iris store result score $to_x_face iris run function iris:raycast/check_intersection/ray_plane
+execute if score $hits_x_face iris matches 0 run scoreboard players set $to_x_face iris 2147483647
+execute if score $hits_x_face iris matches 1 run data modify storage iris:data TargetPoint set from storage iris:data Face.Collision
+
 data modify storage iris:data Face set from storage iris:data Faces[1]
 execute store success score $hits_y_face iris store result score $to_y_face iris run function iris:raycast/check_intersection/ray_plane
+execute if score $hits_y_face iris matches 0 run scoreboard players set $to_y_face iris 2147483647
+execute if score $hits_y_face iris matches 1 if score $to_y_face iris < $to_x_face iris run data modify storage iris:data TargetPoint set from storage iris:data Face.Collision
+
 data modify storage iris:data Face set from storage iris:data Faces[2]
 execute store success score $hits_z_face iris store result score $to_z_face iris run function iris:raycast/check_intersection/ray_plane
+execute if score $hits_z_face iris matches 0 run scoreboard players set $to_z_face iris 2147483647
+execute if score $hits_z_face iris matches 1 if score $to_z_face iris < $to_x_face iris if score $to_z_face iris < $to_y_face iris run data modify storage iris:data TargetPoint set from storage iris:data Face.Collision
 
 # If no face was hit, fail; otherwise, return the shortest distance to any face that is hit
 execute if score $hits_x_face iris matches 0 if score $hits_y_face iris matches 0 if score $hits_z_face iris matches 0 run return fail
-execute if score $hits_x_face iris matches 0 run scoreboard players set $to_x_face iris 2147483647
-execute if score $hits_y_face iris matches 0 run scoreboard players set $to_y_face iris 2147483647
-execute if score $hits_z_face iris matches 0 run scoreboard players set $to_z_face iris 2147483647
 scoreboard players operation $to_aabb iris = $to_x_face iris
 scoreboard players operation $to_aabb iris < $to_y_face iris
 scoreboard players operation $to_aabb iris < $to_z_face iris

--- a/data/iris/functions/raycast/check_intersection/ray_plane.mcfunction
+++ b/data/iris/functions/raycast/check_intersection/ray_plane.mcfunction
@@ -23,14 +23,8 @@ execute store result score $x1 iris run data get storage iris:data Face.max[0] 1
 execute store result score $y1 iris run data get storage iris:data Face.max[1] 1000000
 execute store result score $z1 iris run data get storage iris:data Face.max[2] 1000000
 
-# Test if the ray is already inside the face
-execute if data storage iris:data {Face: {Direction: "WEST_EAST"}} if score ${x} iris = $x0 iris if score ${y} iris >= $y0 iris if score ${y} iris <= $y1 iris if score ${z} iris >= $z0 iris if score ${z} iris <= $z1 iris run return 0
-execute if data storage iris:data {Face: {Direction: "UP_DOWN"}} if score ${y} iris = $y0 iris if score ${x} iris >= $x0 iris if score ${x} iris <= $x1 iris if score ${z} iris >= $z0 iris if score ${z} iris <= $z1 iris run return 0
-execute if data storage iris:data {Face: {Direction: "NORTH_SOUTH"}} if score ${z} iris = $z0 iris if score ${x} iris >= $x0 iris if score ${x} iris <= $x1 iris if score ${y} iris >= $y0 iris if score ${y} iris <= $y1 iris run return 0
-
-# If it is not, see where the intersection between the plane and the ray would be
-    # Get distance (in mm) to the plane, i.e. how long the ray should extend before it hits the plane
-    # This value should be at most sqrt(3)*1000; if it's more than 2000, we fail (otherwise we risk overflow errors)
+# Get distance (in mm) to the plane, i.e. how long the ray should extend before it hits the plane
+# This value should be at most sqrt(3)*1000; if it's more than 2000, we fail (otherwise we risk overflow errors)
 execute if data storage iris:data {Face: {Direction: "WEST_EAST"}} run scoreboard players operation $distance iris = $x0 iris
 execute if data storage iris:data {Face: {Direction: "WEST_EAST"}} run scoreboard players operation $distance iris -= ${x} iris
 execute if data storage iris:data {Face: {Direction: "UP_DOWN"}} run scoreboard players operation $distance iris = $y0 iris
@@ -44,26 +38,32 @@ execute if data storage iris:data {Face: {Direction: "NORTH_SOUTH"}} run scorebo
 execute if score $distance iris matches ..-1 run return fail
 execute if score $distance iris matches 2000.. run return fail
 
-    # Get x position of the ray/plane intersection
+# Get x position of the ray/plane intersection
 scoreboard players operation $x_intersection iris = $distance iris
 scoreboard players operation $x_intersection iris *= $dx iris
 scoreboard players operation $x_intersection iris /= $1000 iris
 scoreboard players operation $x_intersection iris += ${x} iris
 execute if data storage iris:data {Face: {Direction: "WEST_EAST"}} run scoreboard players operation $x_intersection iris = $x0 iris
 
-    # Get y position of the ray/plane intersection
+# Get y position of the ray/plane intersection
 scoreboard players operation $y_intersection iris = $distance iris
 scoreboard players operation $y_intersection iris *= $dy iris
 scoreboard players operation $y_intersection iris /= $1000 iris
 scoreboard players operation $y_intersection iris += ${y} iris
 execute if data storage iris:data {Face: {Direction: "UP_DOWN"}} run scoreboard players operation $y_intersection iris = $y0 iris
 
-    # Get z position of the ray/plane intersection
+# Get z position of the ray/plane intersection
 scoreboard players operation $z_intersection iris = $distance iris
 scoreboard players operation $z_intersection iris *= $dz iris
 scoreboard players operation $z_intersection iris /= $1000 iris
 scoreboard players operation $z_intersection iris += ${z} iris
 execute if data storage iris:data {Face: {Direction: "NORTH_SOUTH"}} run scoreboard players operation $z_intersection iris = $z0 iris
+
+# Save the position of the intersection
+data modify storage iris:data Face.Collision set value [0.0d, 0.0d, 0.0d]
+execute store result storage iris:data Face.Collision[0] double 0.000001 run scoreboard players get $x_intersection iris
+execute store result storage iris:data Face.Collision[1] double 0.000001 run scoreboard players get $y_intersection iris
+execute store result storage iris:data Face.Collision[2] double 0.000001 run scoreboard players get $z_intersection iris
 
 # See if that intersection falls within the face
 execute if score $x_intersection iris >= $x0 iris if score $x_intersection iris <= $x1 iris \

--- a/data/iris/functions/raycast/on_hit.mcfunction
+++ b/data/iris/functions/raycast/on_hit.mcfunction
@@ -12,21 +12,36 @@ execute if score $entity_hit iris matches 1 if score $block_hit iris matches 0 r
 execute if score $block_hit iris matches 1 if score $entity_hit iris matches 1 if score $block_distance iris <= $entity_distance iris run data modify storage iris:output TargetType set value "BLOCK"
 execute if score $block_hit iris matches 1 if score $entity_hit iris matches 1 if score $block_distance iris > $entity_distance iris run data modify storage iris:output TargetType set value "ENTITY"
 
-# Write targeted block/targeted entity
+# Write targeted block
 execute if data storage iris:output {TargetType: "BLOCK"} run data modify storage iris:output TargetedBlock set value [0, 0, 0]
 execute if data storage iris:output {TargetType: "BLOCK"} store result storage iris:output TargetedBlock[0] int 1 run scoreboard players get $[x] iris
 execute if data storage iris:output {TargetType: "BLOCK"} store result storage iris:output TargetedBlock[1] int 1 run scoreboard players get $[y] iris
 execute if data storage iris:output {TargetType: "BLOCK"} store result storage iris:output TargetedBlock[2] int 1 run scoreboard players get $[z] iris
 execute if data storage iris:output {TargetType: "BLOCK"} align xyz run summon minecraft:marker ~0.5 ~0.5 ~0.5 {Tags: ["iris", "iris.targeted_block"]}
 
+# Write targeted entity
 execute if data storage iris:output {TargetType: "ENTITY"} run data modify storage iris:output TargetedEntity set from storage iris:data TargetedBox.entity_id
+execute if data storage iris:output {TargetType: "ENTITY"} run data remove storage iris:data TargetedBox.entity_id
+execute if data storage iris:output {TargetType: "ENTITY"} run data remove storage iris:data TargetedFace.entity_id
 execute if data storage iris:output {TargetType: "ENTITY"} store result score $entity_id iris run data get storage iris:output TargetedEntity
 execute if data storage iris:output {TargetType: "ENTITY"} as @e[tag=iris.possible_target] if score @s iris.id = $entity_id iris run tag @s add iris.targeted_entity
-tag @e remove iris.possible_target
+execute if data storage iris:output {TargetType: "ENTITY"} run tag @e remove iris.possible_target
 
-# Write targeted box/face
-execute if data storage iris:output {TargetType: "BLOCK"} run data modify storage iris:output TargetedBox set from storage iris:data TargetedBox
-execute if data storage iris:output {TargetType: "BLOCK"} run data modify storage iris:output TargetedFace set from storage iris:data TargetedFace
+# Write target position
+execute unless data storage iris:output {TargetType: "NONE"} run data modify storage iris:output TargetPosition.tile set value [0, 0, 0]
+execute unless data storage iris:output {TargetType: "NONE"} store result storage iris:output TargetPosition.tile[0] int 1 run scoreboard players get $[x] iris
+execute unless data storage iris:output {TargetType: "NONE"} store result storage iris:output TargetPosition.tile[1] int 1 run scoreboard players get $[y] iris
+execute unless data storage iris:output {TargetType: "NONE"} store result storage iris:output TargetPosition.tile[2] int 1 run scoreboard players get $[z] iris
+execute unless data storage iris:output {TargetType: "NONE"} run data modify storage iris:output TargetPosition.point set from storage iris:data TargetPoint
+execute unless data storage iris:output {TargetType: "NONE"} store result score ${x} iris run data get storage iris:output TargetPosition.point[0] 1000000
+execute unless data storage iris:output {TargetType: "NONE"} store result score ${y} iris run data get storage iris:output TargetPosition.point[1] 1000000
+execute unless data storage iris:output {TargetType: "NONE"} store result score ${z} iris run data get storage iris:output TargetPosition.point[2] 1000000
+
+# Write targeted box
+execute unless data storage iris:output {TargetType: "NONE"} run data modify storage iris:output TargetedBox set from storage iris:data TargetedBox
+
+# Write targeted face
+execute unless data storage iris:output {TargetType: "NONE"} run data modify storage iris:output TargetedFace set from storage iris:data TargetedFace
 
 # Write total distance
 execute if data storage iris:output {TargetType: "BLOCK"} run scoreboard players operation $total_distance iris += $block_distance iris


### PR DESCRIPTION
- Creates a new `TargetPosition` field in output for target types `BLOCK` and `ENTITY`
  - `TargetPosition.tile` contains the world coordinates of the last traversed tile
  - `TargetPosition.point` contains the exact coordinates within that tile (between `0.0` and `1.0`) where the ray lands
- Also sets scores `${x}`, `${y}`, `${z}` to the coordinates where the ray lands within the last traversed tile (this was already supposed to be the case)
  - Now `iris:set_position/main` can be used directly after running `iris:get_target` to teleport an entity to the precise target point:
```mcfunction
function iris:get_target
execute unless data storage iris:output {TargetType: "NONE"} run function iris:set_coordinates/main
```