### PR TITLE
Correct entity width of medium pufferfish

### DIFF
--- a/data/iris/function/get_hitbox/entity/shape_groups/pufferfish.mcfunction
+++ b/data/iris/function/get_hitbox/entity/shape_groups/pufferfish.mcfunction
@@ -1,6 +1,6 @@
 execute store result score $pufferfish_puffstate iris run data get entity @s PuffState
 execute if score $pufferfish_puffstate iris matches 0 run scoreboard players set $entity_width iris 350000
-execute if score $pufferfish_puffstate iris matches 1 run scoreboard players set $entity_width iris 500000
+execute if score $pufferfish_puffstate iris matches 1 run scoreboard players set $entity_width iris 490000
 execute if score $pufferfish_puffstate iris matches 2 run scoreboard players set $entity_width iris 700000
 scoreboard players operation $entity_height iris = $entity_width iris
 


### PR DESCRIPTION
[The Minecraft wiki](https://minecraft.wiki/w/Hitbox#Variable_hitbox_sizes) says `PuffState: 1` pufferfish are 0.49x0.49, and this code snippet below (from CFR decompiler) backs it up too.

```java
@Override
public EntityDimensions getDefaultDimensions(Pose $$0) {
    return super.getDefaultDimensions($$0).scale(Pufferfish.getScale(this.getPuffState()));
}

private static float getScale(int $$0) {
    switch ($$0) {
        case 1: {
            return 0.7f;
        }
        case 0: {
            return 0.5f;
        }
    }
    return 1.0f;
}
```
