### PR TITLE
Allow dynamically overriding the context of a raycast

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,16 @@ If a block was hit, a marker with the `iris.targeted_block` tag is summoned in t
 
 Settings of the function can be modified in the `iris:settings` storage:
 
-| Tag                 | Description                                              | Default value |
-|---------------------|----------------------------------------------------------|---------------|
-| `MaxRecursionDepth` | How many blocks to traverse before giving up             | 16            |
-| `TargetEntities`    | Whether or not to look for collisions with entities      | `false`       |
-| `Callback`          | A function or function tag to run where the raycast ends | Unset         |
-| `Blacklist`         | Which blocks to ignore during block traversal            | `"#iris:air"` |
-| `Whitelist`         | The only blocks to look for during traversal             | Unset         |
+| Tag                   | Description                                                    | Default value |
+|-----------------------|----------------------------------------------------------------|---------------|
+| `MaxRecursionDepth`   | How many blocks to traverse before giving up                   | 16            |
+| `TargetEntities`      | Whether or not to look for collisions with entities            | `false`       |
+| `Callback`            | A function or function tag to run where the raycast ends       | Unset         |
+| `Blacklist`           | Which blocks to ignore during block traversal                  | `"#iris:air"` |
+| `Whitelist`           | The only blocks to look for during traversal                   | Unset         |
+| `OverrideCoordinates` | Force raycast to start at coordinates different than executor  | Unset         |
+| `OverrideSteering`    | Force raycast to use steering vector different than executor   | Unset         |
+	
 
 If both `Blacklist` and `Whitelist` are set, all blocks outside of the whitelist or in the blacklist will be ignored. If both `Blacklist` and `Whitelist` are unset, collisions will be tested for all tiles traversed. It is recommended that blocks with no outline (e.g. `air`) be blacklisted, or that a whitelist be set up to ignore them.
 

--- a/data/iris/function/get_position/main.mcfunction
+++ b/data/iris/function/get_position/main.mcfunction
@@ -27,6 +27,10 @@
 #    score #dz iris
 #        The z coordinate of the steering vector of the ray, represented by an integer between -1000000 and 1000000
 
-function iris:get_position/get_coordinates
-function iris:get_position/get_rotation
+execute if data storage iris:settings OverrideCoordinates run function iris:get_position/override_coordinates
+execute unless data storage iris:settings OverrideCoordinates run function iris:get_position/get_coordinates
+
+execute if data storage iris:settings OverrideSteering run function iris:get_position/override_steering
+execute unless data storage iris:settings OverrideSteering run function iris:get_position/get_rotation
+
 kill @s

--- a/data/iris/function/get_position/main.mcfunction
+++ b/data/iris/function/get_position/main.mcfunction
@@ -6,7 +6,6 @@
 #
 # @context a marker
 # @within iris:get_target
-# @within iris:get_hitbox/entity
 # @writes
 #    score $[x] iris
 #        The integer x coordinate of the current position

--- a/data/iris/function/get_position/override_coordinates.mcfunction
+++ b/data/iris/function/get_position/override_coordinates.mcfunction
@@ -1,0 +1,15 @@
+#> iris:get_position/override_coordinates
+#
+# @within iris:get_position/main
+
+
+# Get integer coordinates
+execute store result score $[x] iris store result storage iris:args x int -1 run data get storage iris:data OverrideCoordinates[0]
+execute store result score $[y] iris store result storage iris:args y int -1 run data get storage iris:data OverrideCoordinates[1]
+execute store result score $[z] iris store result storage iris:args z int -1 run data get storage iris:data OverrideCoordinates[2]
+
+# Get fractional coordinates
+execute store result score ${x} iris run data get storage iris:data OverrideCoordinates[0] 1000000
+execute store result score ${y} iris run data get storage iris:data OverrideCoordinates[1] 1000000
+execute store result score ${z} iris run data get storage iris:data OverrideCoordinates[2] 1000000
+

--- a/data/iris/function/get_position/override_steering.mcfunction
+++ b/data/iris/function/get_position/override_steering.mcfunction
@@ -1,0 +1,9 @@
+#> iris:get_position/override_steering
+#
+#
+# @context A marker and a rotation
+# @within iris:get_position/main
+
+execute store result score $dx iris run data get storage iris:data OverrideSteering[0]
+execute store result score $dy iris run data get storage iris:data OverrideSteering[1]
+execute store result score $dz iris run data get storage iris:data OverrideSteering[2]


### PR DESCRIPTION
Yes, it is technically possible already using `$execute positioned $(x) $(y) $(z) facing ~$(dx) ~$(dy) ~$(dz) run function iris:get_target`, but this commit allows end users to avoid excessive macro invocations.